### PR TITLE
Fixed unicode characters outputting issue

### DIFF
--- a/traktor_nowplaying/core.py
+++ b/traktor_nowplaying/core.py
@@ -118,7 +118,7 @@ class TrackWriter:
         else:
             tracklist = '\n'.join(self._get_track_string(t) for t in self.tracks)
 
-        with open(self.outfile, 'w') as f:
+        with io.open(self.outfile, 'w', encoding="utf-8") as f:
             f.write(tracklist)
 
 


### PR DESCRIPTION
This change works on my computer when trying to output foreign characters to a text file.

Setting those environment variables can also help fixing local exceptions on your machine if your Windows command-line throws you an exception as well.
set PYTHONIOENCODING=utf-8
set PYTHONLEGACYWINDOWSSTDIO=utf-8
